### PR TITLE
Change the plugin title to improve publishing on https://plugins.jenkins.io/log-file-filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# JENKINS File Filter Log Plugin
+Jenkins File Filter Log Plugin
+===============================
 
 This plugin allows filtering Jenkins' console output by means of regular expressions. Some expressions are included by default; to see which are the default expressions go to the Jenkins global settings and click the "Enable default regexp" help icon. They can be turned off by unchecking the "Enable default regexp" checkbox.
 


### PR DESCRIPTION
Just noticed while exploring plugins using GitHub as `<url>`. Last week we enabled GitHub documentation publishing, so README.md is now published on ins.io/log-file-filter . This change improves the layout a bit.

FTR, announcement in the developer mailing list: https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A