### PR TITLE
avoid logging empty lines, so removing complete log lines becomes possible

### DIFF
--- a/src/main/java/com/tsystems/sbs/LogFileFilterOutputStream.java
+++ b/src/main/java/com/tsystems/sbs/LogFileFilterOutputStream.java
@@ -33,7 +33,7 @@ public class LogFileFilterOutputStream extends LineTransformationOutputStream {
     private final List<RegexpPair> customRegexpPairs;
     private final String jobName;
 	
-	private final Pattern NON_WHITESPACE_PATTERN = Pattern.compile(".*\\S.*");
+	private final Pattern AT_LEAST_ONE_NON_WHITESPACE_PATTERN = Pattern.compile(".*\\S.*\\r?\\n?");
 
 
     public LogFileFilterOutputStream(OutputStream out, Charset charset, String jobName, LogFileFilterConfig config) {
@@ -103,7 +103,7 @@ public class LogFileFilterOutputStream extends LineTransformationOutputStream {
                             "Filtered logfile for {0} output ''{1}''.", new Object[]{jobName, line});
                 }
 				
-                if (NON_WHITESPACE_PATTERN.matcher(line).matches()) {
+                if (AT_LEAST_ONE_NON_WHITESPACE_PATTERN.matcher(line).matches()) {
                     logger.write(line.getBytes(charset));
                 }
             } else {

--- a/src/main/java/com/tsystems/sbs/LogFileFilterOutputStream.java
+++ b/src/main/java/com/tsystems/sbs/LogFileFilterOutputStream.java
@@ -100,7 +100,9 @@ public class LogFileFilterOutputStream extends LineTransformationOutputStream {
                     LOGGER.log(Level.FINE, 
                             "Filtered logfile for {0} output ''{1}''.", new Object[]{jobName, line});
                 }
-                logger.write(line.getBytes(charset));
+                if (line.length() > 0) {
+                    logger.write(line.getBytes(charset));
+                }
             } else {
                 // no change, write the bytes as-is to avoid messing with the encoding
                 logger.write(bytes, 0, len);

--- a/src/main/java/com/tsystems/sbs/LogFileFilterOutputStream.java
+++ b/src/main/java/com/tsystems/sbs/LogFileFilterOutputStream.java
@@ -100,7 +100,8 @@ public class LogFileFilterOutputStream extends LineTransformationOutputStream {
                     LOGGER.log(Level.FINE, 
                             "Filtered logfile for {0} output ''{1}''.", new Object[]{jobName, line});
                 }
-                if (line.length() > 0) {
+				
+                if (line.length() > 1) {
                     logger.write(line.getBytes(charset));
                 }
             } else {

--- a/src/main/java/com/tsystems/sbs/LogFileFilterOutputStream.java
+++ b/src/main/java/com/tsystems/sbs/LogFileFilterOutputStream.java
@@ -32,6 +32,8 @@ public class LogFileFilterOutputStream extends LineTransformationOutputStream {
     private final List<RegexpPair> defaultRegexpPairs;
     private final List<RegexpPair> customRegexpPairs;
     private final String jobName;
+	
+	private final Pattern NON_WHITESPACE_PATTERN = Pattern.compile(".*\\S.*");
 
 
     public LogFileFilterOutputStream(OutputStream out, Charset charset, String jobName, LogFileFilterConfig config) {
@@ -101,7 +103,7 @@ public class LogFileFilterOutputStream extends LineTransformationOutputStream {
                             "Filtered logfile for {0} output ''{1}''.", new Object[]{jobName, line});
                 }
 				
-                if (line.length() > 1) {
+                if (NON_WHITESPACE_PATTERN.matcher(line).matches()) {
                     logger.write(line.getBytes(charset));
                 }
             } else {


### PR DESCRIPTION
So far it was not possible to completly filter log lines. Even when the regex matched to complete line, the plugin still logged an empty line, so the build log contains many, many empty lines.
With this PR empty lines won't be logged any more, so build logs become cleaner.
